### PR TITLE
feat(bukkit): add PatheticBukkit.shutdown to release plugin-scoped state

### DIFF
--- a/core/src/main/java/de/bsommerfeld/pathetic/bukkit/PatheticBukkit.java
+++ b/core/src/main/java/de/bsommerfeld/pathetic/bukkit/PatheticBukkit.java
@@ -10,6 +10,7 @@ import org.bstats.bukkit.Metrics;
 import org.bstats.charts.SimplePie;
 import org.bstats.charts.SingleLineChart;
 import org.bukkit.Bukkit;
+import org.bukkit.event.HandlerList;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -20,6 +21,8 @@ public class PatheticBukkit {
   private static final int B_STATS_ID = 29080;
 
   private static JavaPlugin instance;
+  private static Metrics metrics;
+  private static ChunkInvalidateListener chunkInvalidateListener;
 
   /**
    * @throws IllegalStateException If an attempt is made to initialize more than 1 time
@@ -29,7 +32,9 @@ public class PatheticBukkit {
     if (instance != null) throw new IllegalStateException("Can't be initialized twice");
 
     instance = javaPlugin;
-    Bukkit.getPluginManager().registerEvents(new ChunkInvalidateListener(), javaPlugin);
+
+    chunkInvalidateListener = new ChunkInvalidateListener();
+    Bukkit.getPluginManager().registerEvents(chunkInvalidateListener, javaPlugin);
 
     initializeBStats(javaPlugin);
 
@@ -45,6 +50,29 @@ public class PatheticBukkit {
     log.debug("Pathetic v{} initialized", Pathetic.getOrLoadEngineVersion());
   }
 
+  /**
+   * Releases all plugin-scoped resources allocated by {@link #initialize(JavaPlugin)}.
+   * <p>
+   * Safe to call from a plugin's onDisable hook or before reloading an isolated
+   * classloader. After this call, {@link #isInitialized()} returns false and
+   * {@link #initialize(JavaPlugin)} can be invoked again.
+   */
+  public static void shutdown() {
+    if (instance == null) return;
+
+    if (metrics != null) {
+      metrics.shutdown();
+      metrics = null;
+    }
+
+    if (chunkInvalidateListener != null) {
+      HandlerList.unregisterAll(chunkInvalidateListener);
+      chunkInvalidateListener = null;
+    }
+
+    instance = null;
+  }
+
   @Deprecated
   public static boolean isInitialized() {
     return instance != null;
@@ -56,7 +84,7 @@ public class PatheticBukkit {
   }
 
   private static void initializeBStats(Plugin javaPlugin) {
-    Metrics metrics = new Metrics(javaPlugin, B_STATS_ID);
+    metrics = new Metrics(javaPlugin, B_STATS_ID);
     metrics.addCustomChart(new SimplePie("pathetic_version", Pathetic::getOrLoadEngineVersion));
     metrics.addCustomChart(
         new SingleLineChart("pathfinding_steps", BStatsUtil::getPathfindingSteps));


### PR DESCRIPTION
Currently, when `PatheticBukkit.initialize` is called, it sets up a few pieces of plugin-scoped state: a static instance, a `ChunkInvalidateListener`, and a bStats `Metrics` with it's executor. The problem is that it immediately discards the references to the listener and metrics, giving callers no way to ever clean them up. 

Because of this, if the host plugin reloads, or if the library is loaded from a classloader that is later closed, these stranded components just keep running in the background. The bStats `ScheduledExecutorService` keeps firing on its fixed cadence, but because the classes are no longer loadable, it throw an error the next submission cycle with:

```
java.lang.NoClassDefFoundError: de/bsommerfeld/pathetic/bstats/json/JsonObjectBuilder$JsonObject
  at de.bsommerfeld.pathetic.bstats.MetricsBase.submitData(MetricsBase.java:180)
  at org.bukkit.craftbukkit.scheduler.CraftTask.run(CraftTask.java:78)
```

The ChunkInvalidateListener gets left behind in the exact same way, actively throwing similar errors.

To resolve this, this PR introduces a proper teardown lifecycle. Instead of discarding the Metrics and listener references during initialization, we now capture them as static fields. This allows us to expose a new PatheticBukkit.shutdown() method.

The method is completely idempotent, and once called, it leaves PatheticBukkit completely ready to be used again via a follow-up initialize call.

For standard plugins that never reload, there is absolutely no change in behavior. This simply provides a much-needed, clean teardown hook for environments that require it.